### PR TITLE
Implement `list` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-.piccologs

--- a/.piccologs/bright-rules-judge-rapidly.md
+++ b/.piccologs/bright-rules-judge-rapidly.md
@@ -1,0 +1,5 @@
+---
+category: feature
+---
+
+Implement `list` command (#2)

--- a/README.md
+++ b/README.md
@@ -18,3 +18,13 @@ You may edit the generated piccolog file in your preferred editor and check it i
 
 Collects all piccologs and writes them nicely formatted to your `CHANGELOG.md` under a given version tag.
 You may edit the updated `CHANGELOG.md` in your preferred editor and commit it to version control.
+
+### `picco list`
+
+#### (alias: `picco ls`)
+
+Collects all piccologs and outputs them to the console. You can optionally use a `--type=<type>` argument to output only changes of a certain type, e.g.,
+
+```shell
+$ npx picco ls --type=migration
+```

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -79,6 +79,6 @@ export async function list(cwd, categories) {
         }
     }
 
-    log.message(buildLog(changeLog).trim());
+    log.message(buildLog(changeLog).trim() || "Nothing to show!");
     outro(pc.italic(pc.green(" Have a nice day! ")));
 }

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -1,0 +1,106 @@
+import { readdir, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { exit } from "node:process";
+import { intro, outro, log } from "@clack/prompts";
+import pc from "picocolors";
+
+import { CATEGORIES_ORDER, CHANGE_CATEGORIES, PICCO_DIR } from "../constants.js";
+
+const LOG_PARSE_REGEX = /\s*---([^]*?)\n\s*---(\s*(?:\n|$)[^]*)/;
+
+/**
+ * @param {string} logContents
+ * @returns {{ category: keyof typeof CHANGE_CATEGORIES; summary: string[]; }}
+ */
+function parsePiccoLog(logContents) {
+    const parseResult = LOG_PARSE_REGEX.exec(logContents);
+
+    if (!parseResult) {
+        throw new Error(`could not parse piccolog - invalid frontmatter: ${logContents}`);
+    }
+
+    const [, rawMetadata, rawSummary] = parseResult;
+    const metadata = Object.fromEntries(rawMetadata.trim().split("\n").map((row) => row.split(": ")));
+    const summary = rawSummary.trim().split("\n");
+
+    return {
+        category: metadata.category,
+        summary,
+    };
+}
+
+/**
+ * @param {keyof typeof CHANGE_CATEGORIES} category
+ * @param {Set<string>} changes
+ * @returns {string}
+ */
+function buildLogCategory(category, changes) {
+    if (changes.size === 0) {
+        return "";
+    }
+
+    let categoryLog = pc.bold(pc.cyan(`${CHANGE_CATEGORIES[category]}\n`));
+
+    for (const change of changes) {
+        categoryLog += `• ${change}\n`;
+    }
+
+    categoryLog += "\n";
+
+    return categoryLog;
+}
+
+/**
+ * @param {Record<keyof typeof CHANGE_CATEGORIES, Set<string>>} changeLog
+ * @returns {string}
+ */
+function buildLog(changeLog) {
+    let finalLog = "";
+
+    for (const category of CATEGORIES_ORDER) {
+        if (category in changeLog) {
+            finalLog += buildLogCategory(category, changeLog[category]);
+        }
+    }
+
+    return finalLog;
+}
+
+/**
+ * @param {string} cwd Current working directory
+ * @param {string[]} categories List of categories to include into the logged output
+ */
+export async function list(cwd, categories) {
+    const piccoPath = resolve(cwd, PICCO_DIR);
+    const piccologs = (await readdir(piccoPath)).filter((fileName) => fileName.endsWith(".md"));
+
+    if (piccologs.length === 0) {
+        console.log("No piccologs found");
+        exit(0);
+    }
+
+    intro(pc.bgCyan(pc.black(` picco list `)));
+
+    const allCategories = Object.keys(CHANGE_CATEGORIES);
+    const filteredCategories = categories.filter((category) => allCategories.includes(category));
+    const categoriesToLog = filteredCategories.length > 0 ? filteredCategories : allCategories;
+
+    /** @type {Record<keyof typeof CHANGE_CATEGORIES, Set<string>>} */
+    const changeLog = Object.fromEntries(categoriesToLog.map((category) => [category, new Set()]));
+
+    for (const logName of piccologs) {
+        const logContents = await readFile(resolve(piccoPath, logName), { encoding: "utf8" });
+        const { category, summary } = parsePiccoLog(logContents);
+
+        if (!categoriesToLog.includes(category)) {
+            continue;
+        }
+
+        for (const line of summary) {
+            changeLog[category].add(line);
+        }
+    }
+
+    log.message(buildLog(changeLog).trim());
+    outro(pc.italic(pc.green(" Have a nice day! ")));
+}

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -5,29 +5,7 @@ import { intro, outro, log } from "@clack/prompts";
 import pc from "picocolors";
 
 import { CATEGORIES_ORDER, CHANGE_CATEGORIES, PICCO_DIR } from "../constants.js";
-
-const LOG_PARSE_REGEX = /\s*---([^]*?)\n\s*---(\s*(?:\n|$)[^]*)/;
-
-/**
- * @param {string} logContents
- * @returns {{ category: keyof typeof CHANGE_CATEGORIES; summary: string[]; }}
- */
-function parsePiccoLog(logContents) {
-    const parseResult = LOG_PARSE_REGEX.exec(logContents);
-
-    if (!parseResult) {
-        throw new Error(`could not parse piccolog - invalid frontmatter: ${logContents}`);
-    }
-
-    const [, rawMetadata, rawSummary] = parseResult;
-    const metadata = Object.fromEntries(rawMetadata.trim().split("\n").map((row) => row.split(": ")));
-    const summary = rawSummary.trim().split("\n");
-
-    return {
-        category: metadata.category,
-        summary,
-    };
-}
+import { parsePiccoLog } from "../parser.js";
 
 /**
  * @param {keyof typeof CHANGE_CATEGORIES} category

--- a/src/commands/version.js
+++ b/src/commands/version.js
@@ -5,13 +5,12 @@ import { intro, outro, isCancel, cancel, multiselect, text, spinner } from "@cla
 import pc from "picocolors";
 
 import { CATEGORIES_ICONS, CATEGORIES_ORDER, CHANGE_CATEGORIES, PICCO_DIR } from "../constants.js";
+import { parsePiccoLog } from "../parser.js";
 
 function onCancel() {
     cancel("Have a nice day!");
     exit(0);
 }
-
-const LOG_PARSE_REGEX = /\s*---([^]*?)\n\s*---(\s*(?:\n|$)[^]*)/;
 
 /** @returns {string} */
 function getDateVersion() {
@@ -21,27 +20,6 @@ function getDateVersion() {
     const day = now.getDate().toString().padStart(2, "0");
 
     return `${year}-${month}-${day}`;
-}
-
-/**
- * @param {string} logContents
- * @returns {{ category: keyof typeof CHANGE_CATEGORIES; summary: string[]; }}
- */
-function parsePiccoLog(logContents) {
-    const parseResult = LOG_PARSE_REGEX.exec(logContents);
-
-    if (!parseResult) {
-        throw new Error(`could not parse piccolog - invalid frontmatter: ${logContents}`);
-    }
-
-    const [, rawMetadata, rawSummary] = parseResult;
-    const metadata = Object.fromEntries(rawMetadata.trim().split("\n").map((row) => row.split(": ")));
-    const summary = rawSummary.trim().split("\n");
-
-    return {
-        category: metadata.category,
-        summary,
-    };
 }
 
 /**

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,0 +1,23 @@
+const LOG_PARSE_REGEX = /\s*---([^]*?)\n\s*---(\s*(?:\n|$)[^]*)/;
+
+/**
+ * @param {string} logContents
+ * @returns {{ category: keyof typeof CHANGE_CATEGORIES; summary: string[]; }}
+ */
+export function parsePiccoLog(logContents) {
+    const parseResult = LOG_PARSE_REGEX.exec(logContents);
+
+    if (!parseResult) {
+        throw new Error(`could not parse piccolog - invalid frontmatter: ${logContents}`);
+    }
+
+    const [, rawMetadata, rawSummary] = parseResult;
+    const metadata = Object.fromEntries(rawMetadata.trim().split("\n").map((row) => row.split(": ")));
+    const summary = rawSummary.trim().split("\n");
+
+    return {
+        category: metadata.category,
+        summary,
+    };
+}
+

--- a/src/run.js
+++ b/src/run.js
@@ -3,6 +3,7 @@ import { argv, cwd, exit } from "node:process";
 import { init } from "./commands/init.js";
 import { add } from "./commands/add.js";
 import { version } from "./commands/version.js";
+import { list } from "./commands/list.js";
 
 export async function run() {
     const rootDir = cwd();
@@ -21,8 +22,18 @@ export async function run() {
             await version(rootDir);
             break;
 
+        case "list":
+        case "ls":
+            const args = argv
+                .slice(3)
+                .filter((arg) => arg.startsWith("--type"))
+                .map((arg) => arg.split("=")[1]);
+
+            await list(rootDir, args);
+            break;
+
         default:
-            console.log("usage: picco <init|add|version>");
+            console.log("usage: picco <init|add|version|list>");
             exit(1);
     }
 }


### PR DESCRIPTION
This PR adds a `list` command (alias: `ls`) that can be used to output all piccologs to the console without modifying the changelog file or deleting the piccologs.
A `--type` argument can be used to filter the output for a certain change category, e.g.,

```shell
$ npx picco ls --type=migration
```

To filter for multiple categories, you can use the `--type` argument multiple times, e.g.,

```shell
$ npx picco ls --type=feature --type=bugfix
```

Closes #1 